### PR TITLE
8 hr. rate limit for watering neighbor's plants

### DIFF
--- a/astrobotany/models.py
+++ b/astrobotany/models.py
@@ -584,7 +584,7 @@ class Plant(BaseModel):
             return "You sprinkle some water over your plant."
 
         query = Plant.select().where(
-            Plant.watered_by == user, Plant.watered_at >= datetime.now() - timedelta(hours=0.5),
+            Plant.watered_by == user, Plant.watered_at >= datetime.now() - timedelta(hours=8),
         )
         if query.exists():
             return "Your watering can is empty, try again later!"

--- a/tests/test_astrobotany.py
+++ b/tests/test_astrobotany.py
@@ -177,7 +177,7 @@ def test_plant_no_fertilizer(now):
 
 def test_plant_water_rate_limit(frozen_time, now):
     """
-    A user can only water one neighbor's plan every 8 hours.
+    A user can only water one neighbor's plant every 8 hours.
     """
     user1 = user_factory()
     user2 = user_factory()
@@ -196,7 +196,13 @@ def test_plant_water_rate_limit(frozen_time, now):
     assert plant2.water_supply_percent == 0
     assert plant2.watered_by is None
 
-    frozen_time.tick(delta=timedelta(hours=12))
+    frozen_time.tick(delta=timedelta(hours=7.5))
+    plant2.water(user3)
+    plant2.save()
+    assert plant2.water_supply_percent == 0
+    assert plant2.watered_by is None
+
+    frozen_time.tick(delta=timedelta(hours=0.6))
     plant2.water(user3)
     plant2.save()
     assert plant2.water_supply_percent == 100


### PR DESCRIPTION
Hi! I noticed that I could water plants in the community garden every 30 minutes, which didn't seem in line with your intentions (as described in #10). I changed the visitor watering rate limit back to every 8 hours (though #10 does propose every 12 hours--not sure if you have a particular preference there). I also added in a short test to confirm that visitor watering attempts 7.5 hours after a previous community watering event should fail; while attempts 8.1 hours after such an event should succeed.

If the switch to every half an hour was intentional, feel free to ignore this. Thanks for making gemini fertile and floriferous!