### PR TITLE
Better formatting for growth_rate

### DIFF
--- a/astrobotany/views.py
+++ b/astrobotany/views.py
@@ -758,7 +758,7 @@ def xmas(request):
 @authenticate
 def info(request):
     request.session["alert"] = "\n".join(
-        [f"Generation: {request.plant.generation}", f"Growth Rate: {request.plant.growth_rate}"]
+        [f"Generation: {request.plant.generation}", f"Growth Rate: {request.plant.growth_rate:#.2}"]
     )
     return Response(Status.REDIRECT_TEMPORARY, "/app/plant")
 


### PR DESCRIPTION
The way that growth_rate is calculated in models.py allows for float representation issues to creep in, which are then propagated to your plants info view when via views.py .
Adjusting the format specification allows us to limit output to a single decimal place.

```python
>>> growth_rate = 1 + 0.2 * (13-1)   # per models.py
>>> growth_rate
3.4000000000000004
>>> f"Growth Rate: {growth_rate}"    # per views.py
'Growth Rate: 3.4000000000000004'
>>> f"Growth Rate: {growth_rate:#.2}"
'Growth Rate: 3.4'
```