### PR TITLE
Change lucky clover emoji to four-leaf version

### DIFF
--- a/astrobotany/templates/garden.gmi
+++ b/astrobotany/templates/garden.gmi
@@ -23,7 +23,7 @@ Currently showing: {{ filter }}
 ## Plants
 
 {% if not search_term and total > 1 %}
-=>/app/garden/{{ filter }}/random ☘️ I'm feeling lucky!
+=>/app/garden/{{ filter }}/random 🍀 I'm feeling lucky!
 
 {% endif %}
 {% for plant in plants %}


### PR DESCRIPTION
I noticed today that the "I'm feeling lucky" link on the garden page has a three-leaf clover.

But the lucky one is supposed to be the four-leaf clover, because it's rare.

Cheers,
Alex