### PR TITLE
Show more info in API

### DIFF
--- a/astrobotany/views.py
+++ b/astrobotany/views.py
@@ -1212,9 +1212,15 @@ def plants_api_view(request):
         response.append(
             {
                 "url": f"gemini://astrobotany.mozz.us/app/visit/{plant.user.user_id}",
+                "name": plant.name,
                 "username": plant.user.username,
                 "description": plant.description,
                 "health": plant.health,
+                "generation": plant.generation,
+                "score": plant.score,
+                "stage": plant.stage,
+                "owner_last_watered": plant.neglected_days,
+                "water_supply": plant.water_supply_percent,
             }
         )
     data = {"response": response}


### PR DESCRIPTION
Show more information in the plants API, so you don't have to query for every plant and waste a lot of astrobotany's server resources.

This could lead to being a privacy issue, as having all the information in one place means someone can easily get the data, when they would have to implement their own parsers and other things to get this data.

If this idea isn't wanted because the API would like to be kept the same, I don't mind it having it under another API endpoint.